### PR TITLE
Fix try catch not working due to "throw new"

### DIFF
--- a/Athena/src/streams/compression/compressedBuffer.cpp
+++ b/Athena/src/streams/compression/compressedBuffer.cpp
@@ -17,7 +17,7 @@ namespace athena
 		size_t size = LZ4F_compressFrame(m_data.data(), m_data.size(), buffer.data(), buffer.size(), &preferences);
 
 		if (LZ4F_isError(size))
-			throw new exceptions::compressionException(LZ4F_getErrorName(size));
+			throw exceptions::compressionException(LZ4F_getErrorName(size));
 
 		m_data.resize(size);
 			
@@ -48,7 +48,7 @@ namespace athena
 	}
 	buffer& compressedBuffer::decompress()
 	{
-		if (!m_data.size()) throw new exceptions::compressionException("m_data.size() was 0!");
+		if (!m_data.size()) throw exceptions::compressionException("m_data.size() was 0!");
 		LZ4F_dctx* p_compressionContext = nullptr;
 		LZ4F_createDecompressionContext(&p_compressionContext,LZ4F_getVersion());
 
@@ -61,7 +61,7 @@ namespace athena
 		LZ4F_errorCode_t error = LZ4F_decompress(p_compressionContext, dstBuffer, &dstSize, data(), &srcSize, nullptr);
 
 		if (LZ4F_isError(error))
-			throw new exceptions::compressionException(LZ4F_getErrorName(error));
+			throw exceptions::compressionException(LZ4F_getErrorName(error));
 
 		buffer* p_buffer = new buffer();
 		p_buffer->writeData((const char*)dstBuffer, dstSize);

--- a/Athena/src/streams/readers/fileStreamReader.cpp
+++ b/Athena/src/streams/readers/fileStreamReader.cpp
@@ -9,9 +9,9 @@ namespace athena
 	{
 		m_stream = std::ifstream(path,std::ifstream::in | std::ifstream::binary);
 
-		if (!m_stream.good()) throw new exceptions::badStreamException("reader stream was bad!");
-		if (!m_stream.is_open()) throw new exceptions::badStreamException("reader stream was not open!");
-		if (!std::filesystem::file_size(path)) throw new exceptions::badStreamException("m_stream filesize was 0! (check if file is open somewhere else in program!)");
+		if (!m_stream.good()) throw exceptions::badStreamException("reader stream was bad!");
+		if (!m_stream.is_open()) throw exceptions::badStreamException("reader stream was not open!");
+		if (!std::filesystem::file_size(path)) throw exceptions::badStreamException("m_stream filesize was 0! (check if file is open somewhere else in program!)");
 		size_t size = std::filesystem::file_size(path);
 
 		char* data = (char*)malloc(size);
@@ -39,7 +39,7 @@ namespace athena
 	}
 	void fileStreamReader::setStreamPosition(size_t index)
 	{
-		if (index < 0 || index > m_sections.size()) throw new exceptions::indexOutOfBoundsException("streamPosition was out of bounds");
+		if (index < 0 || index > m_sections.size()) throw exceptions::indexOutOfBoundsException("streamPosition was out of bounds");
 		m_sectionIndex = index;
 	}
 	void fileStreamReader::previousStreamSection()

--- a/Athena/src/streams/writers/fileStreamWriter.cpp
+++ b/Athena/src/streams/writers/fileStreamWriter.cpp
@@ -12,8 +12,8 @@ namespace athena
 	{
 		m_stream = std::ofstream(path, std::ofstream::out | std::ofstream::binary);
 
-		if (!m_stream.good()) throw new exceptions::badStreamException("writer stream was bad!");
-		if (!m_stream.is_open()) throw new exceptions::badStreamException("writer stream was not open!");
+		if (!m_stream.good()) throw exceptions::badStreamException("writer stream was bad!");
+		if (!m_stream.is_open()) throw exceptions::badStreamException("writer stream was not open!");
 
 		sections.resize(1);
 	}
@@ -31,7 +31,7 @@ namespace athena
 	}
 	void fileStreamWriter::setStreamPosition(size_t index)
 	{
-		if (index < 0 || index > sections.size()) throw new exceptions::indexOutOfBoundsException("streamPosition was out of bounds");
+		if (index < 0 || index > sections.size()) throw exceptions::indexOutOfBoundsException("streamPosition was out of bounds");
 		sectionIndex = index;
 	}
 	void fileStreamWriter::previousStreamSection()

--- a/Athena/src/util/buffer.cpp
+++ b/Athena/src/util/buffer.cpp
@@ -25,6 +25,6 @@ namespace athena
 	}
 	void buffer::setPointerPosition(size_t index)
 	{
-		if (m_pointerPosition + index > m_data.size()) throw new exceptions::indexOutOfBoundsException("index was out of bounds"); //TODO custom exception with print statement
+		if (m_pointerPosition + index > m_data.size()) throw exceptions::indexOutOfBoundsException("index was out of bounds"); //TODO custom exception with print statement
 	}
 }


### PR DESCRIPTION
Hello,
I am trying out the library and became very confused after it threw an uncaught exception despite me using a try-catch.

Error handling in Athena seems to be done with 'throw new' instead of 'new', which seems to be causing this problem.
I assume this is a mistake and not intentional, so I'm making this PR.

```cpp

/* snip */

int main()
{
    try
    {
        auto path = std::filesystem::path("./assets.doom");
        auto streamWriter = athena::fileStreamWriter(path);
        DoomPackageHeader pkgHeader{1};
        streamWriter.writeObject(pkgHeader);
        streamWriter.nextStreamSection();

        {
            int fileSize;
            unsigned char *data = LoadFileData("ComfyUI_00372_.png", &fileSize);

            auto header = DoomAssetHeader{"ComfyUI_00372_.png", static_cast<uint64_t>(fileSize)};
            streamWriter.writeObject(header);
            streamWriter.writeData((const char *)data, fileSize);
        }

        streamWriter.flush();
    }
    catch (const std::exception& ex)
    {
        std::cerr << ex.what() << std::endl;
    }
    
/* snip */

}
```
![image](https://github.com/user-attachments/assets/41ddf413-47b8-4370-a4b3-842f2a47f110)
